### PR TITLE
truncate extended for directories/marketplace search results

### DIFF
--- a/tendenci/themes/t7-base/templates/directories/search-result.html
+++ b/tendenci/themes/t7-base/templates/directories/search-result.html
@@ -55,9 +55,9 @@
       
       <p class="item-content">
         {% if directory.summary %}
-        {{ directory.summary|striptags|truncatewords:15|safe }}
+        {{ directory.summary|striptags|truncatewords:50|safe }}
         {% else %}
-        {{ directory.body|striptags|truncatewords:15|safe }}
+        {{ directory.body|striptags|truncatewords:50|safe }}
         {% endif %}
       </p>
     </div>


### PR DESCRIPTION
Allows the text to fill the "marketplace" bodies instead of truncating and inserting "..." in it's place.