### PR TITLE
More ses fixes

### DIFF
--- a/tendenci/apps/newsletters/utils.py
+++ b/tendenci/apps/newsletters/utils.py
@@ -60,8 +60,13 @@ def get_newsletter_connection():
 def is_newsletter_relay_set():
     connection = settings.NEWSLETTER_EMAIL_BACKEND
     if connection == "django_ses.SESBackend":
-        return all([settings.AWS_ACCESS_KEY_ID,
-                    settings.AWS_SECRET_ACCESS_KEY])
+        if settings.AWS_ACCESS_KEY_ID and settings.AWS_SECRET_ACCESS_KEY:
+            return all([settings.AWS_ACCESS_KEY_ID,
+                        settings.AWS_SECRET_ACCESS_KEY])
+        else:
+            return all([settings.AWS_SES_ACCESS_KEY_ID,
+                        settings.AWS_SES_SECRET_ACCESS_KEY])
+
     else:
         return all([settings.NEWSLETTER_EMAIL_HOST,
                     settings.NEWSLETTER_EMAIL_HOST_USER,

--- a/tendenci/apps/newsletters/utils.py
+++ b/tendenci/apps/newsletters/utils.py
@@ -60,12 +60,16 @@ def get_newsletter_connection():
 def is_newsletter_relay_set():
     connection = settings.NEWSLETTER_EMAIL_BACKEND
     if connection == "django_ses.SESBackend":
-        if settings.AWS_ACCESS_KEY_ID and settings.AWS_SECRET_ACCESS_KEY:
-            return all([settings.AWS_ACCESS_KEY_ID,
-                        settings.AWS_SECRET_ACCESS_KEY])
-        else:
+        if settings.AWS_SES_ACCESS_KEY_ID:
+            ses_acc_key = True
+        if settings.AWS_SES_SECRET_ACCESS_KEY:
+            ses_sec_key = True
+        if ses_acc_key and ses_sec_key:
             return all([settings.AWS_SES_ACCESS_KEY_ID,
                         settings.AWS_SES_SECRET_ACCESS_KEY])
+        else:
+            return all([settings.AWS_ACCESS_KEY_ID,
+                        settings.AWS_SECRET_ACCESS_KEY])
 
     else:
         return all([settings.NEWSLETTER_EMAIL_HOST,


### PR DESCRIPTION
Added the ability to use the django.SES naming convention. This gives separation from primary AWS keys and allows a separate SES keys to be used if the primary keys are used elsewhere and not for SES.